### PR TITLE
Api version and module version upgrades

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.5.0',
+      version='1.6.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',
@@ -13,8 +13,8 @@ setup(name='tap-google-ads',
           'singer-python @ git+https://github.com/peliqan-io/singer-python@master',
           'requests==2.26.0',
           'backoff==1.8.0',
-          'google-ads==21.0.0',
-          'protobuf==4.22.3',
+          'google-ads==22.1.0',
+          'protobuf==4.24.4',
 
           # Necessary to handle gRPC exceptions properly, documented
           # in an issue here: https://github.com/googleapis/python-api-core/issues/301

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -14,7 +14,7 @@ from . import report_definitions
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "v13"
+API_VERSION = "v15"
 
 API_PARAMETERS = {
     "omit_unselected_resource_names": "true"


### PR DESCRIPTION
# Description of change
Version Changes mentioned in https://www.notion.so/peliqan/Update-tap-google-ads-2b83e2db46e14ac2aca0235db8878b73 are as : 

1. Overall version change of tap-google-ads from 1.5.0 to 1.6.0
2. Version change of Google-ads from 21.0.0 to 22.1.0
3. protobuf version change from 4.22.3 to 4.24.4
4. API version changed to "v15"

# Rollback steps
 - revert this branch
