### PR TITLE
 fix: resource_name schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.6.0',
+      version='1.6.1',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -131,7 +131,7 @@ def build_resource_metadata(api_objects, resource):
         7: {"type": ["null", "integer"]},
         8: {"type": ["null", "integer"]},
         9: {"type": ["null", "object", "string"], "properties": {}},
-        10: {"type": ["null", "object", "string"], "properties": {}},
+        10: {"type": ["null", "string"]},
         11: {"type": ["null", "string"]},
         12: {"type": ["null", "integer"]},
     }

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -131,7 +131,7 @@ def build_resource_metadata(api_objects, resource):
         7: {"type": ["null", "integer"]},
         8: {"type": ["null", "integer"]},
         9: {"type": ["null", "object", "string"], "properties": {}},
-        9: {"type": ["null", "object", "string"], "properties": {}},
+        10: {"type": ["null", "object", "string"], "properties": {}},
         11: {"type": ["null", "string"]},
         12: {"type": ["null", "integer"]},
     }

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -131,10 +131,13 @@ def build_resource_metadata(api_objects, resource):
         7: {"type": ["null", "integer"]},
         8: {"type": ["null", "integer"]},
         9: {"type": ["null", "object", "string"], "properties": {}},
-        10: {"type": ["null", "string"]},
+        9: {"type": ["null", "object", "string"], "properties": {}},
         11: {"type": ["null", "string"]},
         12: {"type": ["null", "integer"]},
     }
+
+    if resource.name in ['call_view.resource_name', 'campaign_label.resource_name']:
+        resource.data_type = 11
 
     resource_metadata = {
         "name": resource.name,


### PR DESCRIPTION
# Description
This PR details the fix for the issue related to key `resource_name` expecting multiple types of data _viz._ `string`,`NULL` and `object`.

In streams like **campaign_emails** and **call_details**, where `resource_name` is primary_key, taget_postgres doesn't allow NULL or Object value to behave as a Primary Key. Hence, an exception is raised.

# Changes Type
:white_large_square: New feature (non-breaking change which adds functionality)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:white_large_square: Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)
