### PR TITLE
🌬️ handled wrong data type of resource key user_list.lookalike_user_list.seed_user_list_ids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.8.1',
+      version='1.8.2',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_google_ads/discover.py
+++ b/tap_google_ads/discover.py
@@ -136,7 +136,7 @@ def build_resource_metadata(api_objects, resource):
         12: {"type": ["null", "integer"]},
     }
 
-    if resource.name in ['call_view.resource_name', 'campaign_label.resource_name']:
+    if resource.name in ['call_view.resource_name', 'campaign_label.resource_name','user_list.lookalike_user_list.seed_user_list_ids']:
         resource.data_type = 11
 
     resource_metadata = {


### PR DESCRIPTION
# Description
This PR details the issue faced when syncing data for one of the client, which gndue to irrelgular type causes the pipeline to break. The issue has been fixed updating the data-type to string as being a `generic` type.

## Issue 
Issue caused when field `seed_user_list_ids` under **user_list** model being assigned as type "Integer" during discovery observed an array value in response from the Google Ads API. This difference of Data-type caused the pipeline to break. 
![image](https://github.com/user-attachments/assets/c88ad1ae-0f73-4a2c-b9bc-b4b6b75fd2df)

## Solution
Made the data type of the resource as "string". Being generic it will handle all the use-cases of the mismatched data.

## Testing
- Tests have been done.
- all integer and array gets converted to string type data.

## Change Type
:white_large_square: New feature (non-breaking change which adds functionality)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:white_large_square: Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)