### PR TITLE
🆙 Update api version to v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.0
+  * Updates API version to 17
+  * [#95](https://github.com/singer-io/tap-google-ads/pull/95)
+
 ## v1.8.0
   * Updates API version to 17
   * Updates pkg version to 25.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-google-ads',
-      version='1.8.0',
+      version='1.9.0',
       description='Singer.io tap for extracting data from the Google Ads API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='tap-google-ads',
           'singer-python==6.0.0',
           'requests==2.26.0',
           'backoff==2.2.1',
-          'google-ads==25.0.0',
+          'google-ads==25.1.0',
           'protobuf==5.28.0',
 
           # Necessary to handle gRPC exceptions properly, documented

--- a/tap_google_ads/streams.py
+++ b/tap_google_ads/streams.py
@@ -14,7 +14,7 @@ from . import report_definitions
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "v17"
+API_VERSION = "v18"
 
 API_PARAMETERS = {
     "omit_unselected_resource_names": "true"


### PR DESCRIPTION
# Description of change
This PR details the version upgrade in GoogleAds API to 18. This has come due to version 17 of Google Ads API got deprecated on June 4,2025. Changes have been non-breaking.

# Testing
- Changes have been tested on local environment


## Change Type
:white_large_square: New feature (non-breaking change which adds functionality)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:white_large_square: Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)